### PR TITLE
fix: mark some peer dependencies as optional and remove some unnecessary peer dependencies

### DIFF
--- a/projects/editor/package.json
+++ b/projects/editor/package.json
@@ -54,26 +54,129 @@
         "@tiptap/extension-text-style": ">=2.4.0",
         "@tiptap/extension-underline": ">=2.4.0",
         "@tiptap/extension-youtube": ">=2.4.0",
-        "@tiptap/pm": ">=2.4.0",
-        "@tiptap/prosemirror-tables": ">=1.1.4",
         "@tiptap/starter-kit": ">=2.4.0",
         "@types/markdown-it": ">=14.1.1",
         "@types/markdown-it-container": ">=2.0.10",
-        "markdown-it": ">=14.1.0",
-        "prosemirror-collab": ">=1.3.1",
-        "prosemirror-commands": ">=1.5.2",
-        "prosemirror-dropcursor": ">=1.8.1",
-        "prosemirror-gapcursor": ">=1.3.2",
-        "prosemirror-history": ">=1.4.0",
-        "prosemirror-inputrules": ">=1.4.0",
-        "prosemirror-keymap": ">=1.2.2",
-        "prosemirror-model": ">=1.21.1",
-        "prosemirror-schema-list": ">=1.3.0",
-        "prosemirror-state": ">=1.4.3",
-        "prosemirror-tables": ">=1.3.7",
-        "prosemirror-transform": ">=1.9.0",
-        "prosemirror-utils": ">=1.2.2",
-        "prosemirror-view": ">=1.33.7"
+        "markdown-it": ">=14.1.0"
+    },
+    "peerDependenciesMeta": {
+        "@maskito/core": {
+            "optional": true
+        },
+        "@maskito/kit": {
+            "optional": true
+        },
+        "@tiptap/extension-blockquote": {
+            "optional": true
+        },
+        "@tiptap/extension-bold": {
+            "optional": true
+        },
+        "@tiptap/extension-bubble-menu": {
+            "optional": true
+        },
+        "@tiptap/extension-bullet-list": {
+            "optional": true
+        },
+        "@tiptap/extension-code": {
+            "optional": true
+        },
+        "@tiptap/extension-code-block": {
+            "optional": true
+        },
+        "@tiptap/extension-dropcursor": {
+            "optional": true
+        },
+        "@tiptap/extension-focus": {
+            "optional": true
+        },
+        "@tiptap/extension-gapcursor": {
+            "optional": true
+        },
+        "@tiptap/extension-hard-break": {
+            "optional": true
+        },
+        "@tiptap/extension-heading": {
+            "optional": true
+        },
+        "@tiptap/extension-highlight": {
+            "optional": true
+        },
+        "@tiptap/extension-history": {
+            "optional": true
+        },
+        "@tiptap/extension-horizontal-rule": {
+            "optional": true
+        },
+        "@tiptap/extension-image": {
+            "optional": true
+        },
+        "@tiptap/extension-italic": {
+            "optional": true
+        },
+        "@tiptap/extension-link": {
+            "optional": true
+        },
+        "@tiptap/extension-list-item": {
+            "optional": true
+        },
+        "@tiptap/extension-ordered-list": {
+            "optional": true
+        },
+        "@tiptap/extension-placeholder": {
+            "optional": true
+        },
+        "@tiptap/extension-strike": {
+            "optional": true
+        },
+        "@tiptap/extension-subscript": {
+            "optional": true
+        },
+        "@tiptap/extension-superscript": {
+            "optional": true
+        },
+        "@tiptap/extension-table": {
+            "optional": true
+        },
+        "@tiptap/extension-table-cell": {
+            "optional": true
+        },
+        "@tiptap/extension-table-header": {
+            "optional": true
+        },
+        "@tiptap/extension-table-row": {
+            "optional": true
+        },
+        "@tiptap/extension-task-item": {
+            "optional": true
+        },
+        "@tiptap/extension-task-list": {
+            "optional": true
+        },
+        "@tiptap/extension-text-align": {
+            "optional": true
+        },
+        "@tiptap/extension-text-style": {
+            "optional": true
+        },
+        "@tiptap/extension-underline": {
+            "optional": true
+        },
+        "@tiptap/extension-youtube": {
+            "optional": true
+        },
+        "@tiptap/starter-kit": {
+            "optional": true
+        },
+        "@types/markdown-it": {
+            "optional": true
+        },
+        "@types/markdown-it-container": {
+            "optional": true
+        },
+        "markdown-it": {
+            "optional": true
+        }
     },
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
- removed `prosemirror-*` from `peerDependencies` since `@tiptap/core` depends on `@tiptap/pm` which in turn [depends on all the `prosemirror-*` packages](https://www.npmjs.com/package/@tiptap/pm?activeTab=dependencies).
- marked optional peer dependencies in `peerDependenciesMeta`
- Some of the `@taiga-ui` peer dependencies like `@taiga-ui/core`, `@taiga-ui/kit`, `@taiga-ui/cdk`, `@taiga-ui/i18n` and `@taiga-ui/legacy` are missing from peer dependencies but I don't know what version should be used. Unreleased `v4`?

Closes #1092 
